### PR TITLE
Improve Nginx log_format adding $http_host

### DIFF
--- a/templates/nginx.conf.hbs
+++ b/templates/nginx.conf.hbs
@@ -16,7 +16,7 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" "$http_host"';
 
     access_log  /var/log/nginx/access.log  main;
 


### PR DESCRIPTION
The common use case of serving as a rev-proxy to multiple docker containers can benefit by adding to the Nginx logs the host for which the request is being made.